### PR TITLE
v0.3.1: Fix edge cases with cluster counts

### DIFF
--- a/ncbi_cluster_tracker/main.py
+++ b/ncbi_cluster_tracker/main.py
@@ -55,6 +55,7 @@ def main() -> None:
         old_clusters_df = pd.read_csv(old_clusters_glob[0])
         old_isolates_df = pd.read_csv(old_isolates_glob[0])
 
+    no_clusters_message = 'No SNP clusters found for the provided isolates. Exiting.'
     if not args.retry:
         os.environ['NCT_NOW'] = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
         os.environ['NCT_OUT_SUBDIR'] = os.path.join(out_dir, os.environ['NCT_NOW'])
@@ -63,6 +64,9 @@ def main() -> None:
             isolates_df, clusters_df = get_clusters(biosamples, args.browser_file)
         else:
             isolates_df, clusters_df = get_clusters(biosamples, 'bigquery')
+        if clusters_df.empty:
+            logger.info(no_clusters_message)
+            return
         download.download_cluster_files(clusters_df, args.keep_snp_files)
     else:
         if not os.path.isdir(out_dir):
@@ -71,6 +75,9 @@ def main() -> None:
         os.environ['NCT_NOW'] = os.path.basename(out_dir.rstrip(os.sep))
         logger.info(f'Retrying with {os.environ["NCT_OUT_SUBDIR"]}')
         isolates_df, clusters_df = get_clusters(biosamples, 'local')
+        if clusters_df.empty:
+            logger.info(no_clusters_message)
+            return
     
     if args.amr:
         amr_ref_df = download.download_amr_reference_file()  

--- a/ncbi_cluster_tracker/report.py
+++ b/ncbi_cluster_tracker/report.py
@@ -783,12 +783,21 @@ def write_final_report(
     cluster_report_blocks = [r.report for r in cluster_reports]
     cluster_report_blocks.sort(key=lambda r: r.label, reverse=True)
 
-    report_blocks = [
-        ar.Page(blocks=cluster_page_blocks, title='Clusters'),
-        ar.Page(
+    # ar.Select requires at least 2 items, so handle single cluster differently
+    if len(cluster_report_blocks) > 1:
+        cluster_details_page = ar.Page(
             ar.Select(blocks=cluster_report_blocks, type=ar.SelectType.DROPDOWN),
             title='Cluster details',
-        ),
+        )
+    else:  # len(cluster_report_blocks) == 1
+        cluster_details_page = ar.Page(
+            blocks=cluster_report_blocks,
+            title='Cluster details',
+        )
+
+    report_blocks = [
+        ar.Page(blocks=cluster_page_blocks, title='Clusters'),
+        cluster_details_page,
         ar.Page(blocks=isolate_page_blocks, title='Isolates'),
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ncbi-cluster-tracker"
-version = "0.3.0"
+version = "0.3.1"
 description = "Create standalone HTML reports for tracking SNP clusters within NCBI Pathogen Detection"
 authors = [
     {name = "Sam Baird",email = "sam.baird@state.co.us"}


### PR DESCRIPTION
This PR 

closes #11 

Fix errors when there are zero or more clusters associated with the isolates in the sample sheet. If there are no clusters found, then the report now will not generate. If there is one cluster, the report will now be successfully created.